### PR TITLE
ci: add Windows build-and-release GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,9 +26,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: dist/*
+          path: dist/**
       - name: Publish GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/Doro.exe
+          files: |
+            dist/Doro.exe
+            dist/resources/**

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,34 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12.9'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Build executable
+        run: python -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+      - name: Publish GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/Doro.exe


### PR DESCRIPTION
- Introduces .github/workflows/build-release.yml
- Triggers on pushes to any branch and tags starting with `v*`
- Grants `contents: write` for release publishing
- Sets up Python 3.x on `windows-latest`
- Installs deps via `pip install -r requirements.txt`
- Builds executable with `python -m build`
- Uploads `dist/*` as artifacts
- On version tags, publishes a GitHub Release with `dist/Doro.exe`